### PR TITLE
Hotfix cli commands

### DIFF
--- a/docs/external-sources/sdk-go.md
+++ b/docs/external-sources/sdk-go.md
@@ -1,0 +1,151 @@
+# Description
+This go SDK is designed to help developers easily integrate Onqlave `Encryption As A Service` into their go backend.
+
+[![CI](https://img.shields.io/static/v1?label=CI&message=passing&color=green?style=plastic&logo=github)](https://github.com/onqlavelabs/onqlave-go/actions)
+[![GitHub release](https://img.shields.io/github/v/release/onqlavelabs/onqlave-go.svg)](https://github.com/onqlavelabs/onqlave-go/releases)
+[![License](https://img.shields.io/github/license/onqlavelabs/onqlave-go)](https://github.com/onqlavelabs/onqlave-go/blob/main/LICENSE)
+
+
+# Table of Contents
+
+- [Description](#description)
+- [Table of Contents](#table-of-contents)
+	- [Features](#features)
+	- [Installation](#installation)
+		- [Requirements](#requirements)
+		- [Configuration](#configuration)
+		- [Usage](#usage)
+		- [Encrypt](#encrypt)
+		- [Decrypt](#decrypt)
+		- [Encrypt Stream](#encrypt-stream)
+		- [Decrypt Stream](#decrypt-stream)
+	- [Reporting a Vulnerability](#reporting-a-vulnerability)
+
+## Features
+
+- Encrypt/Decrypt piece of information
+- Encrypt/Decrypt stream of data
+
+## Installation
+
+### Requirements
+- go 1.18 and above
+
+### Configuration
+
+Make sure your project is using Go Modules (it will have a go.mod file in its root if it already is):
+
+```go
+go mod init
+```
+
+Then, reference onqlave-go in a Go program with import:
+
+```go
+import (
+  onqlave "github.com/onqlavelabs/onqlave-go"
+)
+```
+Alternatively, `go get github.com/onqlavelabs/onqlave-go` can also be used to download the required dependencies
+
+### Usage
+
+To use this SDK, you firstly need to obtain credential to access an Onqlave Arx by signing up to [Onqlave](https://onqlave.com) and following instruction to create your 1st Onqlave Arx. Documentation can be found at [Onqlave Technical Documentation](https://docs.onqlave.com).
+
+The [Onqlave Go](https://github.com/onqlavelabs/onqlave-go) module is used to perform operations on the configured ARX such as encrypting, and decrypting for an Onqlave_ARX. [example](https://github.com/onqlavelabs/onqlave-go/blob/main/examples/main.go):
+
+To use this module, the Onqlave client must first be initialized as follows.
+
+```go
+import (
+	"github.com/onqlavelabs/onqlave-go/onqlave/onqlaveconnection"
+	"github.com/onqlavelabs/onqlave-go/onqlave/onqlavecredentials"
+	"github.com/onqlavelabs/onqlave-go/onqlave/onqlaveencryption"
+)
+
+debugOption := onqlaveencryption.WithDebug(true) //This option lets you choose whether to start SDK operation in debug mode to info mode
+arxOption := onqlaveencryption.WithArx("<arx_url>") //This is the Arx URL retruned of the API Key created during setup. Keep in in a safe place.
+credentialOption := onqlaveencryption.WithCredential(onqlavecredentials.Credential{
+	AccessKey:  "<api_access_key>",   //This is the API Access Key returned of the API Key created during setup. Keep in in a safe place.
+	SigningKey: "<api_signing_key>",  //This is the API Signing Key retruned of the API Key created during setup. Keep in in a safe place.
+	SecretKey:  "<api_secret_key>",   //This is the API Secret Key retruned of the API Key created during setup. Keep in in a safe place.
+})
+retryOption := onqlaveencryption.WithRetry(onqlaveconnection.RetrySettings{
+	Count:       <count>,         //Number of times to retry calling server endpoints in case of connection issue
+	WaitTime:    <wait_time>,     //How long to wait between each retry
+	MaxWaitTime: <max_wait_time>, //How long to wait in total for operation to finish
+})
+
+service := encryption.NewEncryption(debugOption, arxOption, credentialOption, retryOption)
+defer service.Close()
+```
+
+All Onqlave APIs must be invoked using a `Encryption` instance.
+
+### Encrypt
+
+To encrypt data, use the **Encrypt(plainText, associatedData []byte)** method of the `Encryption` service. The **plainText** parameter is the `[]byte` representation of data you are wishing to encrypt. The **associatedData** parameter the `[]byte` representation of associated data which can be used to improve the authenticity of the data (it is not mandatory), as shown below.
+
+Encrypt call:
+
+```go
+
+//Initilise the new encryption service using configurations as per [Usage]
+service := encryption.NewEncryption(debugOption, arxOption, credentialOption, retryOption)
+defer service.Close()
+
+plainData := []byte("this data needs to be encrypted")
+associatedData := []byte("this data needs to be authenticated, but not encrypted") //This can be an arbitrary piece of information you can use to for added security purpose.
+cipherData, err := service.Encrypt(plainData, associatedData)
+```
+
+
+### Decrypt
+To encrypt data, use the **Decrypt(cipherData, associatedData []byte)** method of the `Encryption` service. The **cipherData** parameter is the `[]byte` representation of data you are wishing to decrypt (previousely encrypted). The **associatedData** parameter the `[]byte` representation of associated data which can be used to improve the authenticity of the data (it is not mandatory), as shown below.
+
+```go
+
+//Initilise the new encryption service using configurations as per [Usage]
+service := encryption.NewEncryption(debugOption, arxOption, credentialOption, retryOption)
+defer service.Close()
+
+cipherData := []byte("this data is already encrypted using `Encrypt` method")
+associatedData := []byte("this data needs to be authenticated, but not encrypted") //This can be an arbitrary piece of information you can use to for added security purpose.
+plainData, err := service.Decrypt(cipherData, associatedData)
+```
+
+### Encrypt Stream
+
+To encrypt stream of data, use the **EncryptStream(plainStream io.Reader, cipherStream io.Writer, associatedData []byte)** method of the `Encryption` service. The **plainStream** parameter is the `io.Reader` stream of data you are wishing to encrypt. The **cipherStream** parameter is the `io.Write` stream you are wishing to write the cipher data to. The **associatedData** parameter the `[]byte` representation of associated data which can be used to improve the authenticity of the data (it is not mandatory), as shown below.
+
+```go
+
+//Initilise the new encryption service using configurations as per [Usage]
+service := encryption.NewEncryption(debugOption, arxOption, credentialOption, retryOption)
+defer service.Close()
+
+plainStream, _ := os.OpenFile("<file or network stream you are wishing to encrypt>", os.O_RDONLY, 0666)
+associatedData := []byte("this data needs to be authenticated, but not encrypted") //This can be an arbitrary piece of information you can use to for added security purpose.
+cipherStream,_ := os.OpenFile("<file or network stream you are whishing to stream the encrypted data to>", os.O_WRONLY, 0666)
+err := service.EncryptStream(plainStream, cipherStream, associatedData)
+```
+
+
+### Decrypt Stream
+To encrypt data, use the **DecryptStream(cipherStream io.Reader, plainStream io.Writer, associatedData []byte)** method of the `Encryption` service. The **cipherStream** parameter is the `io.Reader` stream of data you are wishing to decrypt and it was originally encrypted using [EncryptStream](#encrypt-stream). The **plainStream** parameter is the `io.Write` stream you are wishing to write the plain data back to. The **associatedData** parameter the `[]byte` representation of associated data which can be used to improve the authenticity of the data (it is not mandatory), as shown below.
+
+```go
+
+//Initilise the new encryption service using configurations as per [Usage]
+service := encryption.NewEncryption(debugOption, arxOption, credentialOption, retryOption)
+defer service.Close()
+
+cipherStream, _ := os.OpenFile("<file or network stream you are wishing to decrypt>", os.O_RDONLY, 0666)
+associatedData := []byte("this data needs to be authenticated, but not encrypted") //This can be an arbitrary piece of information you can use to for added security purpose.
+plainStream,_ := os.OpenFile("<file or network stream you are whishing to stream the decrypted data to>", os.O_WRONLY, 0666)
+err := service.DecryptStreamcipherStream, plainStream, associatedData)
+```
+
+## Reporting a Vulnerability
+
+If you discover a potential security issue in this project, please reach out to us at security@onqlave.com. Please do not create public GitHub issues or Pull Requests, as malicious actors could potentially view them.

--- a/docs/external-sources/sdk-go.md
+++ b/docs/external-sources/sdk-go.md
@@ -148,4 +148,4 @@ err := service.DecryptStreamcipherStream, plainStream, associatedData)
 
 ## Reporting a Vulnerability
 
-If you discover a potential security issue in this project, please reach out to us at security@onqlave.com. Please do not create public GitHub issues or Pull Requests, as malicious actors could potentially view them.
+If you discover a potential security issue in this project, please reach out to us at <security@onqlave.com>. Please do not create public GitHub issues or Pull Requests, as malicious actors could potentially view them.

--- a/docs/external-sources/sdk-node.md
+++ b/docs/external-sources/sdk-node.md
@@ -1,0 +1,136 @@
+# Description
+This node SDK is designed to help developers easily integrate Onqlave `Encryption As A Service` into their node backend.
+
+[![CI](https://img.shields.io/static/v1?label=CI&message=passing&color=green?style=plastic&logo=github)](https://github.com/onqlavelabs/onqlave-node/actions)
+[![GitHub release](https://badge.fury.io/js/onqlave-node.svg)](https://www.npmjs.com/package/onqlave-node)
+[![License](https://img.shields.io/github/license/onqlavelabs/onqlave-node)](https://github.com/onqlavelabs/onqlave-node/blob/main/LICENSE)
+
+
+# Table of Contents
+
+- [Description](#description)
+- [Table of Contents](#table-of-contents)
+	- [Features](#features)
+	- [Installation](#installation)
+		- [Requirements](#requirements)
+		- [Configuration](#configuration)
+		- [Usage](#usage)
+		- [Encrypt](#encrypt)
+		- [Decrypt](#decrypt)
+		- [Encrypt Stream](#encrypt-stream)
+		- [Decrypt Stream](#decrypt-stream)
+	- [Reporting a Vulnerability](#reporting-a-vulnerability)
+
+
+## Features
+
+- Encrypt/Decrypt piece of information
+- Encrypt/Decrypt stream of data
+
+## Installation
+
+### Requirements
+- Node 7.6.0 and above
+
+### Configuration
+
+```sh
+npm install onqlave-node
+
+```
+### Usage
+
+To use this SDK, you firstly need to obtain credential to access an Onqlave Arx by signing up to [Onqlave](https://onqlave.com) and following instruction to create your 1st Onqlave Arx.
+
+The [Onqlave Node](https://github.com/onqlavelabs/onqlave-node) module is used to perform operations on the configured ARX such as encrypting, and decrypting for an Onqlave_ARX. [example](https://github.com/onqlavelabs/onqlave-node/blob/main/examples/index.js):
+
+To use this module, the Onqlave client must first be initialized as follows.
+
+```javascript
+const { Encryption, withCredential, withRetry, withArx, Credential, RetrySettings } = require('onqlave-node');
+const { createReadStream, createWriteStream } = require('fs');
+```
+Or using ES modules
+
+```javascript
+import { Encryption, withCredential, withRetry, withArx, Credential, RetrySettings }  from 'onqlave-node';
+import { createReadStream, createWriteStream } from 'fs';
+
+const arxOption = withArx("<arx_url>"); //This is the Arx URL retruned of the API Key created during setup. Keep in in a safe place.
+const apiKey = "<api_access_key>"       //This is the API Access Key returned of the API Key created during setup. Keep in in a safe place.
+const signingKey = "<api_signing_key>"  //This is the API Signing Key retruned of the API Key created during setup. Keep in in a safe place.
+const secretKey = "<api_secret_key>"    //This is the API Secret Key retruned of the API Key created during setup. Keep in in a safe place.
+const credentialOption = withCredential(new Credential(apiKey, signingKey, secretKey));
+const retryOption = withRetry(new RetrySettings(2, 400, 2000));
+
+const service = new Encryption(arxOption, credentialOption, retryOption);
+```
+
+All Onqlave APIs must be invoked using a `Encryption` instance.
+
+### Encrypt
+
+To encrypt data, use the **Encrypt(plainData, associatedData)** method of the `Encryption` service. The **plainText** parameter is the `Buffer` representation of data you are wishing to encrypt. The **associatedData** parameter the `Buffer` representation of associated data which can be used to improve the authenticity of the data (it is not mandatory), as shown below.
+
+```javascript
+
+//Initilise the new encryption service using configurations as per [Usage]
+const service = new Encryption(arxOption, credentialOption, retryOption);
+
+const plainData = Buffer.from("This is the plain data");
+const additionalData = Buffer.from("This is to authenticated not to encrypt"); //This can be an arbitrary piece of information you can use to for added security purpose.
+cipherData := await service.Encrypt(plainData, associatedData)
+```
+
+
+### Decrypt
+To encrypt data, use the **Decrypt(cipherData, associatedData)** method of the `Encryption` service. The **cipherData** parameter is the `Buffer` representation of data you are wishing to decrypt (previousely encrypted). The **associatedData** parameter the `Buffer` representation of associated data which can be used to improve the authenticity of the data (it is not mandatory), as shown below.
+
+```javascript
+
+//Initilise the new encryption service using configurations as per [Usage]
+const service = new Encryption(arxOption, credentialOption, retryOption);
+
+const cipherData := Buffer.from("this data is already encrypted using `Encrypt` method")
+const additionalData = Buffer.from("This is to authenticated not to encrypt"); //This can be an arbitrary piece of information you can use to for added security purpose.
+plainData := await service.Decrypt(cipherData, associatedData)
+```
+
+### Encrypt Stream
+
+To encrypt stream of data, use the **encryptStream(plainStream, cipherStream, associatedData)** method of the `Encryption` service. The **plainStream** parameter is the `ReadStream` stream of data you are wishing to encrypt. The **cipherStream** parameter is the `WriteStream` stream you are wishing to write the cipher data to. The **associatedData** parameter the `Buffer` representation of associated data which can be used to improve the authenticity of the data (it is not mandatory), as shown below.
+
+
+```javascript
+
+//Initilise the new encryption service using configurations as per [Usage]
+const service = new Encryption(arxOption, credentialOption, retryOption);
+
+const plainStream = createReadStream("<file or network stream you are wishing to encrypt>", { highWaterMark: 64 * 1024 });
+const cipherStream = createWriteStream("<file or network stream you are whishing to stream the encrypted data to>", { encoding: 'binary' });
+const associatedData := Buffer.from("this data needs to be authenticated, but not encrypted") //This can be an arbitrary piece of information you can use to for added security purpose.
+await service.encryptStream(plainStream, cipherStream, additionalData);
+plainStream.close();
+cipherStream.close();
+```
+
+
+### Decrypt Stream
+To encrypt data, use the **decryptStream(cipherStream, plainStream, associatedData)** method of the `Encryption` service. The **cipherStream** parameter is the `ReadStream` stream of data you are wishing to decrypt and it was originally encrypted using [EncryptStream](#encrypt-stream). The **plainStream** parameter is the `WriteStream` stream you are wishing to write the plain data back to. The **associatedData** parameter the `Buffer` representation of associated data which can be used to improve the authenticity of the data (it is not mandatory), as shown below.
+
+```javascript
+
+//Initilise the new encryption service using configurations as per [Usage]
+const service = new Encryption(arxOption, credentialOption, retryOption);
+
+const cipherStream = createReadStream("<file or network stream you are wishing to decrypt>", { encoding: 'binary' });
+const plainStream = createWriteStream("<file or network stream you are whishing to stream the decrypted data to>", { highWaterMark: 64 * 1024 });
+const associatedData := Buffer.from("this data needs to be authenticated, but not encrypted") //This can be an arbitrary piece of information you can use to for added security purpose.
+await service.decryptStream(cipherStream, plainStream, additionalData);
+plainStream.close();
+cipherStream.close();
+```
+
+## Reporting a Vulnerability
+
+If you discover a potential security issue in this project, please reach out to us at security@onqlave.com. Please do not create public GitHub issues or Pull Requests, as malicious actors could potentially view them.

--- a/docs/external-sources/sdk-node.md
+++ b/docs/external-sources/sdk-node.md
@@ -133,4 +133,4 @@ cipherStream.close();
 
 ## Reporting a Vulnerability
 
-If you discover a potential security issue in this project, please reach out to us at security@onqlave.com. Please do not create public GitHub issues or Pull Requests, as malicious actors could potentially view them.
+If you discover a potential security issue in this project, please reach out to us at <security@onqlave.com>. Please do not create public GitHub issues or Pull Requests, as malicious actors could potentially view them.

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -1,22 +1,22 @@
 
 ## **Get your early access account**
 
-Before using Onqlave Platform, we will help you **get an account for FREE**. All you need to do is:
+Before using the Onqlave Platform, we will help you **get an account for FREE**. All you need to do is:
 
 1. <mark><a href="https://www.onqlave.com/contact" target="_blank"> Register for our latest release here </a></mark>
-2. Activate your account by kindly going through the provided instruction
+2. Activate your account by kindly going through the provided instruction via an email from Onqlave Communication service <comms@onqlave.com>
 
-After having your account ready, you can continue with your preffered way of interacting as listed below.
+After having your account ready, you can continue with your preferred way of interacting as listed below.
 
 
 ## **Choose your own flavor**
 
-After having your account, you can easily interact with Onqlave Platform via 2 types of interface. Please note that the managed components are the same in each interface.
+After having your account, you can easily interact with the Onqlave Platform via 2 types of interface. Please note that the managed components are the same in each interface.
 
 ### **1. [Graphical Interface ](../../guides/web-app-guide/overview-gui)**
 
-This graphical interface is accessible via a web browser. You can process to <mark>[this guide](../../guides/web-app-guide/overview-gui)</mark> and get everything ready in 5 minutes.
+This graphical interface is accessible via a web browser. You can proceed to <mark>[this guide](../../guides/web-app-guide/overview-gui)</mark> and get everything ready in 5 minutes.
 
 ### **2. [Command Line Interface ](../../guides/cli-guide/overview-cli)**
 
-The CLI is a widely preffered options for developers and technology enthusiasts. Although we have already included a descriptive manual help command in the CLI itself, we also provide <mark>[a comprehensive document for CLI at this section](../../guides/cli-guide/overview-cli)</mark>.
+The CLI is a widely preffered preferred options for developers and technology enthusiasts. Although we have already included a descriptive manual help command in the CLI itself, we also provide <mark>[a comprehensive document for the CLI here.](guides/cli-guide/overview-cli)</mark>

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -19,4 +19,4 @@ This graphical interface is accessible via a web browser. You can proceed to <ma
 
 ### **2. [Command Line Interface ](../../guides/cli-guide/overview-cli)**
 
-The CLI is a widely preffered preferred options for developers and technology enthusiasts. Although we have already included a descriptive manual help command in the CLI itself, we also provide <mark>[a comprehensive document for the CLI here.](guides/cli-guide/overview-cli)</mark>
+The CLI is a widely preferred option for developers and technology enthusiasts. Although we have already included a descriptive manual help command in the CLI itself, we also provide <mark>[comprehensive documentation for the CLI here.](guides/cli-guide/overview-cli)</mark>

--- a/docs/guides/cli-guide/administration/apikey.md
+++ b/docs/guides/cli-guide/administration/apikey.md
@@ -1,6 +1,6 @@
 ## **Before you start**
 
-The CLI commands to manage API Keys allow you to bring your clusters and applications together. The API Keys created here will draw on all of the unique inputs you have created for the cluster and application that you choose.
+The CLI commands to manage API Keys allow you to bring your arx and applications together. The API Keys created here will draw on all of the unique inputs you have created for the arx and application that you choose.
 
 When you create your key it is critical that you store it as it will only be displayed once. To preserve the integrity of the key, Onqlave does not keep a record of this. Do not close the final window  until you have made this record!
 
@@ -43,7 +43,7 @@ Output will be formatted in tabular format
 │ Key            Value                                  │
 │───────────────────────────────────────────────────────│
 │ ID             apikey--43hUyLzyeVOLQE3YGj7Zw          │
-│ ClusterID      cluster--IRTlZ7UswEEwUwzczWiO0         │
+│ ClusterID      arx--IRTlZ7UswEEwUwzczWiO0         │
 │ ApplicationID  app--gp-OxVE4vuxQ8jrPEh8cw        
 │ CreatedAt      2023-05-02 12:27:15.147192 +0000 UTC   │
 │ Status         active                                 │
@@ -150,7 +150,7 @@ API Key Base Information =>
             "name": "Thelma Schmidt"
         }
     ],
-    "clusters": [
+    "arx": [
         {
             "created_by": {
                 "avatar": "",
@@ -163,7 +163,7 @@ API Key Base Information =>
                 "id": "aes-gcm-256",
                 "name": "AES-GCM-256"
             },
-            "id": "cluster---CSjvl4DuOygw8sYXJntm",
+            "id": "arx---CSjvl4DuOygw8sYXJntm",
             "label": "",
             "name": "Marquise Douglas",
             "plan": {
@@ -200,7 +200,7 @@ API Key Base Information =>
                 "id": "aes-gcm-256",
                 "name": "AES-GCM-256"
             },
-            "id": "cluster--YcvryC1LtCGmTLXQUJJyP",
+            "id": "arx--YcvryC1LtCGmTLXQUJJyP",
             "label": "",
             "name": "Horace Gibson",
             "plan": {
@@ -237,7 +237,7 @@ API Key Base Information =>
                 "id": "aes-gcm-256",
                 "name": "AES-GCM-256"
             },
-            "id": "cluster--v8eE3s1EnT8bYpjU2C6Wj",
+            "id": "arx--v8eE3s1EnT8bYpjU2C6Wj",
             "label": "",
             "name": "Sister Jerde",
             "plan": {

--- a/docs/guides/cli-guide/administration/apikey.md
+++ b/docs/guides/cli-guide/administration/apikey.md
@@ -19,14 +19,14 @@ To create your api key, your have to specify your application_id, application_te
 # onqlave key add -a your_application_id -c your_arx_id -t your_application_technology
 ```
 
-The output log will include the ID of the newly created apikey
+The output log will include the ID of the newly created APIKey
 ```
 🎉 Done! API Key created successfully.
 API Key ID: apikey--your_api_key
 For more information, read our documentation at https://www.onqlave.com/docs
 ```
 
-## **Desribe an API key**
+## **Describe an API key**
 
 **Who can perform this operation?**
 
@@ -43,8 +43,8 @@ Output will be formatted in tabular format
 │ Key            Value                                  │
 │───────────────────────────────────────────────────────│
 │ ID             apikey--43hUyLzyeVOLQE3YGj7Zw          │
-│ ClusterID      arx--IRTlZ7UswEEwUwzczWiO0         │
-│ ApplicationID  app--gp-OxVE4vuxQ8jrPEh8cw        
+│ ClusterID      arx--IRTlZ7UswEEwUwzczWiO0             │
+│ ApplicationID  app--gp-OxVE4vuxQ8jrPEh8cw       
 │ CreatedAt      2023-05-02 12:27:15.147192 +0000 UTC   │
 │ Status         active                                 │
 │ AccessKey      Rhnlij2fJWFXvTp1DxpVdKcwpy6c2IO1       │
@@ -60,7 +60,7 @@ Output will be formatted in tabular format
 
 ```
 # onqlave key list
-``` 
+```
 
 By default, the result will be formatted in a table. If you want JSON format, simply appending the **--json** at the end of the above command
 
@@ -70,7 +70,7 @@ By default, the result will be formatted in a table. If you want JSON format, si
 │───────────────────────────────────────────────────────│
 │                                                       │
 │                                                       |                │                                                       |
-│                                                       |────────────────────────────────────────────────────────┘                
+│                                                       |────────────────────────────────────────────────────────┘               
 
 
 ```
@@ -86,33 +86,33 @@ By default, the result will be formatted in a table. If you want JSON format, si
 # onqlave key delete your_app_key_id
 ```
 
-## **Explore availabe commands**
+## **Explore available commands**
 
 ```
-# onqlave key 
+# onqlave key
 ```
 
 ```
 This command is used to manage api key resources.
 
 Usage:
-  onqlave key [command]
+ onqlave key [command]
 
 Examples:
 onqlave key
 
 Available Commands:
-  add         add api key by attributes
-  base        get base
-  delete      delete api key by ID
-  describe    describe api key by ID
-  list        list api key
+ add         add api key by attributes
+ base        get base
+ delete      delete api key by ID
+ describe    describe api key by ID
+ list        list api key
 
 Flags:
-  -h, --help   help for key
+ -h, --help   help for key
 
 Global Flags:
-      --json   Output logs as JSON.  Set to true if stdout is not a TTY.
+     --json   Output logs as JSON.  Set to true if stdout is not a TTY.
 
 Use "onqlave key [command] --help" for more information about a command.
 ```
@@ -120,10 +120,11 @@ Use "onqlave key [command] --help" for more information about a command.
 
 ## **Get base configuration information for API Keys**
 
-Before interacting with API key, you may need to retrieve all the base information about arx and aplication. The most frequently used information when interacting with API key via CLI are IDs of arx, application and owner
+Before interacting with the API key, you may need to retrieve all the base information about arx and application. The most frequently used information when interacting with API key via CLI are IDs of arx, application and owner
+
 
 ```
-# onqlave key base      
+# onqlave key base     
 ```
 
 Output should be similar to this, you can alternate the format into JSON by appending **--json** into the end of the command:
@@ -133,135 +134,135 @@ Output should be similar to this, you can alternate the format into JSON by appe
 ```
 API Key Base Information =>
 {
-    "applications": [
-        {
-            "application_technology": {
-                "cors": false,
-                "description": "",
-                "enable": false,
-                "icon": "ServerIcon",
-                "id": "server",
-                "is_default": false,
-                "name": "Server",
-                "order": 0
-            },
-            "id": "app--zovKQ3NESVrtHMoPJgr5m",
-            "label": "",
-            "name": "Thelma Schmidt"
-        }
-    ],
-    "arx": [
-        {
-            "created_by": {
-                "avatar": "",
-                "email_address": "your_email@gmail.com",
-                "id": "Qtc2e7LVjSO7Q1tJm0PwaoeVFUS2",
-                "name": "Platform"
-            },
-            "encryption": {
-                "icon": "LockIcon",
-                "id": "aes-gcm-256",
-                "name": "AES-GCM-256"
-            },
-            "id": "arx---CSjvl4DuOygw8sYXJntm",
-            "label": "",
-            "name": "Marquise Douglas",
-            "plan": {
-                "icon": "ServerIcon",
-                "name": "Serverless"
-            },
-            "provider": {
-                "image": "image-gcp.svg",
-                "name": "Google Cloud"
-            },
-            "purpose": {
-                "name": "Development"
-            },
-            "regions": [
-                {
-                    "icon": "icon-australia.svg",
-                    "name": "Australia"
-                }
-            ],
-            "rotation_cycle": {
-                "id": "3-monthly",
-                "name": "3 Monthly"
-            }
-        },
-        {
-            "created_by": {
-                "avatar": "",
-                "email_address": "your_email@gmail.com",
-                "id": "Qtc2e7LVjSO7Q1tJm0PwaoeVFUS2",
-                "name": "Platform"
-            },
-            "encryption": {
-                "icon": "LockIcon",
-                "id": "aes-gcm-256",
-                "name": "AES-GCM-256"
-            },
-            "id": "arx--YcvryC1LtCGmTLXQUJJyP",
-            "label": "",
-            "name": "Horace Gibson",
-            "plan": {
-                "icon": "ServerIcon",
-                "name": "Serverless"
-            },
-            "provider": {
-                "image": "image-gcp.svg",
-                "name": "Google Cloud"
-            },
-            "purpose": {
-                "name": "Development"
-            },
-            "regions": [
-                {
-                    "icon": "icon-australia.svg",
-                    "name": "Australia"
-                }
-            ],
-            "rotation_cycle": {
-                "id": "monthly",
-                "name": "Monthly"
-            }
-        },
-        {
-            "created_by": {
-                "avatar": "",
-                "email_address": "your_email@gmail.com",
-                "id": "Qtc2e7LVjSO7Q1tJm0PwaoeVFUS2",
-                "name": "Platform"
-            },
-            "encryption": {
-                "icon": "LockIcon",
-                "id": "aes-gcm-256",
-                "name": "AES-GCM-256"
-            },
-            "id": "arx--v8eE3s1EnT8bYpjU2C6Wj",
-            "label": "",
-            "name": "Sister Jerde",
-            "plan": {
-                "icon": "ServerIcon",
-                "name": "Serverless"
-            },
-            "provider": {
-                "image": "image-gcp.svg",
-                "name": "Google Cloud"
-            },
-            "purpose": {
-                "name": "Development"
-            },
-            "regions": [
-                {
-                    "icon": "icon-australia.svg",
-                    "name": "Australia"
-                }
-            ],
-            "rotation_cycle": {
-                "id": "monthly",
-                "name": "Monthly"
-            }
-        }
-    ]
-}   
+   "applications": [
+       {
+           "application_technology": {
+               "cors": false,
+               "description": "",
+               "enable": false,
+               "icon": "ServerIcon",
+               "id": "server",
+               "is_default": false,
+               "name": "Server",
+               "order": 0
+           },
+           "id": "app--zovKQ3NESVrtHMoPJgr5m",
+           "label": "",
+           "name": "Thelma Schmidt"
+       }
+   ],
+   "arx": [
+       {
+           "created_by": {
+               "avatar": "",
+               "email_address": "your_email@gmail.com",
+               "id": "Qtc2e7LVjSO7Q1tJm0PwaoeVFUS2",
+               "name": "Platform"
+           },
+           "encryption": {
+               "icon": "LockIcon",
+               "id": "aes-gcm-256",
+               "name": "AES-GCM-256"
+           },
+           "id": "arx---CSjvl4DuOygw8sYXJntm",
+           "label": "",
+           "name": "Marquise Douglas",
+           "plan": {
+               "icon": "ServerIcon",
+               "name": "Serverless"
+           },
+           "provider": {
+               "image": "image-gcp.svg",
+               "name": "Google Cloud"
+           },
+           "purpose": {
+               "name": "Development"
+           },
+           "regions": [
+               {
+                   "icon": "icon-australia.svg",
+                   "name": "Australia"
+               }
+           ],
+           "rotation_cycle": {
+               "id": "3-monthly",
+               "name": "3 Monthly"
+           }
+       },
+       {
+           "created_by": {
+               "avatar": "",
+               "email_address": "your_email@gmail.com",
+               "id": "Qtc2e7LVjSO7Q1tJm0PwaoeVFUS2",
+               "name": "Platform"
+           },
+           "encryption": {
+               "icon": "LockIcon",
+               "id": "aes-gcm-256",
+               "name": "AES-GCM-256"
+           },
+           "id": "arx--YcvryC1LtCGmTLXQUJJyP",
+           "label": "",
+           "name": "Horace Gibson",
+           "plan": {
+               "icon": "ServerIcon",
+               "name": "Serverless"
+           },
+           "provider": {
+               "image": "image-gcp.svg",
+               "name": "Google Cloud"
+           },
+           "purpose": {
+               "name": "Development"
+           },
+           "regions": [
+               {
+                   "icon": "icon-australia.svg",
+                   "name": "Australia"
+               }
+           ],
+           "rotation_cycle": {
+               "id": "monthly",
+               "name": "Monthly"
+           }
+       },
+       {
+           "created_by": {
+               "avatar": "",
+               "email_address": "your_email@gmail.com",
+               "id": "Qtc2e7LVjSO7Q1tJm0PwaoeVFUS2",
+               "name": "Platform"
+           },
+           "encryption": {
+               "icon": "LockIcon",
+               "id": "aes-gcm-256",
+               "name": "AES-GCM-256"
+           },
+           "id": "arx--v8eE3s1EnT8bYpjU2C6Wj",
+           "label": "",
+           "name": "Sister Jerde",
+           "plan": {
+               "icon": "ServerIcon",
+               "name": "Serverless"
+           },
+           "provider": {
+               "image": "image-gcp.svg",
+               "name": "Google Cloud"
+           },
+           "purpose": {
+               "name": "Development"
+           },
+           "regions": [
+               {
+                   "icon": "icon-australia.svg",
+                   "name": "Australia"
+               }
+           ],
+           "rotation_cycle": {
+               "id": "monthly",
+               "name": "Monthly"
+           }
+       }
+   ]
+}  
 ```

--- a/docs/guides/cli-guide/administration/application.md
+++ b/docs/guides/cli-guide/administration/application.md
@@ -205,6 +205,47 @@ Application Base Information =>
 }
 ```
 
+## **Get base configuration information for Application**
+
+These information may be useful when you need to input the required flags during the creation of an application. To get these information, use the following command:
+
+```
+# onqlave application base
+```
+
+Result will be organized either in tabular format by default or can be converted to JSON by appending **--json** flag at the end of the command
+
+![application-base](https://t36712295.p.clickup-attachments.com/t36712295/6fb8663c-bccb-4362-a6a5-043668b2233b/image.png)
+
+JSON output:
+```
+Application Base Information =>
+{
+    "technologies": [
+        {
+            "cors": false,
+            "description": "Application which contains backend",
+            "enable": false,
+            "icon": "ServerIcon",
+            "id": "server",
+            "is_default": false,
+            "name": "Server",
+            "order": 0
+        },
+        {
+            "cors": true,
+            "description": "Application which contains frontend",
+            "enable": false,
+            "icon": "ChromeIcon",
+            "id": "client",
+            "is_default": false,
+            "name": "Client",
+            "order": 1
+        }
+    ]
+}
+```
+
 
 ## **Explore availabe commands**
 

--- a/docs/guides/cli-guide/administration/application.md
+++ b/docs/guides/cli-guide/administration/application.md
@@ -246,6 +246,47 @@ Application Base Information =>
 }
 ```
 
+## **Get base configuration information for Application**
+
+These information may be useful when you need to input the required flags during the creation of an application. To get these information, use the following command:
+
+```
+# onqlave application base
+```
+
+Result will be organized either in tabular format by default or can be converted to JSON by appending **--json** flag at the end of the command
+
+![application-base](https://t36712295.p.clickup-attachments.com/t36712295/6fb8663c-bccb-4362-a6a5-043668b2233b/image.png)
+
+JSON output:
+```
+Application Base Information =>
+{
+    "technologies": [
+        {
+            "cors": false,
+            "description": "Application which contains backend",
+            "enable": false,
+            "icon": "ServerIcon",
+            "id": "server",
+            "is_default": false,
+            "name": "Server",
+            "order": 0
+        },
+        {
+            "cors": true,
+            "description": "Application which contains frontend",
+            "enable": false,
+            "icon": "ChromeIcon",
+            "id": "client",
+            "is_default": false,
+            "name": "Client",
+            "order": 1
+        }
+    ]
+}
+```
+
 
 ## **Explore availabe commands**
 

--- a/docs/guides/cli-guide/administration/application.md
+++ b/docs/guides/cli-guide/administration/application.md
@@ -1,6 +1,7 @@
 # **Before you start**
 
-The related CLI commands of Application will allow you to create and allocate the unique identifiers for your front and backend applications to be used when creating API Keys. This seperate Application workflow ensures you have easy access to enabling, disabling and archiving applications as needed.
+The related CLI commands of Application will allow you to create and allocate the unique identifiers for your front and backend applications to be used when creating API Keys. This separated Application workflow ensures you have easy access to enabling, disabling and archiving applications as needed.
+
 
 When the application reference is created, an API token and encryption key is established. Note that Onqlave does not allow you to permanently delete any applications, however they can be archived, which will then disable the respective API token and encryption key.
 
@@ -13,7 +14,7 @@ You may need to look at the supported [available commands for application](#expl
 - [Platform Owner](../../../web-app-guide/platform/access/#1-platform-owner)
 
 ```
-# onqlave application add your_app_name -d your_preferred_description -t application_technology -o application_owner_id 
+# onqlave application add your_app_name -d your_preferred_description -t application_technology -o application_owner_id
 ```
 
 Then the returned output should include your created application ID
@@ -50,26 +51,26 @@ The output is formatted as a table or JSON depends on your choice of appending *
 
 ```
 {
-    "Application": {
-        "acl": {
-            "can": {
-                "archive": false,
-                "disabled": true,
-                "edit": true
-            },
-            "can_not": {
-                "archive_reason": "Application is not disabled yet!"
-            }
-        },
-        "api_keys": 0,
-        "application_id": "your_app_id_here",
-        "cors": [],
-        "description": "",
-        "name": "app-2",
-        "owner": "owner_id",
-        "status": "active",
-        "technology": "server"
-    }
+   "Application": {
+       "acl": {
+           "can": {
+               "archive": false,
+               "disabled": true,
+               "edit": true
+           },
+           "can_not": {
+               "archive_reason": "Application is not disabled yet!"
+           }
+       },
+       "api_keys": 0,
+       "application_id": "your_app_id_here",
+       "cors": [],
+       "description": "",
+       "name": "app-2",
+       "owner": "owner_id",
+       "status": "active",
+       "technology": "server"
+   }
 }
 
 ```
@@ -100,7 +101,7 @@ The output will be displayed as a table by default. And you can show the JSON ou
 
 - [Platform Owner](../../../web-app-guide/platform/access/#1-platform-owner)
 
-Currently, Onqlave platform supports update an application via it's ID
+Currently, Onqlave platform supports update an application via its ID
 
 ```
 # onqlave application update your_application_id your_list_of_flags_and_values
@@ -115,21 +116,21 @@ And explore all the flags:
 
 ```
 Usage:
-  onqlave application update [flags]
+ onqlave application update [flags]
 
 Examples:
 onqlave application update
 
 Flags:
-  -c, --application_cors string          Enter Application Cors
-  -d, --application_description string   Enter Application Description
-  -n, --application_name string          Enter Application Name
-  -o, --application_owner string         Enter Application Owner
-  -t, --application_technology string    Enter Application Technology
-  -h, --help                             help for update
+ -c, --application_cors string          Enter Application Cors
+ -d, --application_description string   Enter Application Description
+ -n, --application_name string          Enter Application Name
+ -o, --application_owner string         Enter Application Owner
+ -t, --application_technology string    Enter Application Technology
+ -h, --help                             help for update
 
 Global Flags:
-      --json   Output logs as JSON.  Set to true if stdout is not a TTY.
+     --json   Output logs as JSON.  Set to true if stdout is not a TTY.
 ```
 
 ## **Disable an application**
@@ -158,7 +159,8 @@ Global Flags:
 
 - [Platform Owner](../../../web-app-guide/platform/access/#1-platform-owner)
 
-Since we do not support deleting application, you can archive it. Before archiving an application, you have to disable it like the previous step.
+Since we do not support deleting applications, you can archive it. Before archiving an application, you have to disable it like the previous step.
+
 
 ```
 # onqlave application archive your_app_id
@@ -166,7 +168,8 @@ Since we do not support deleting application, you can archive it. Before archivi
 
 ## **Get base configuration information for Application**
 
-These information may be useful when you need to input the required flags during the creation of an application. To get these information, use the following command:
+This information may be useful when you need to input the required flags during the creation of an application. To get these information, use the following command:
+
 
 ```
 # onqlave application base
@@ -180,28 +183,28 @@ JSON output:
 ```
 Application Base Information =>
 {
-    "technologies": [
-        {
-            "cors": false,
-            "description": "Application which contains backend",
-            "enable": false,
-            "icon": "ServerIcon",
-            "id": "server",
-            "is_default": false,
-            "name": "Server",
-            "order": 0
-        },
-        {
-            "cors": true,
-            "description": "Application which contains frontend",
-            "enable": false,
-            "icon": "ChromeIcon",
-            "id": "client",
-            "is_default": false,
-            "name": "Client",
-            "order": 1
-        }
-    ]
+   "technologies": [
+       {
+           "cors": false,
+           "description": "Application which contains backend",
+           "enable": false,
+           "icon": "ServerIcon",
+           "id": "server",
+           "is_default": false,
+           "name": "Server",
+           "order": 0
+       },
+       {
+           "cors": true,
+           "description": "Application which contains frontend",
+           "enable": false,
+           "icon": "ChromeIcon",
+           "id": "client",
+           "is_default": false,
+           "name": "Client",
+           "order": 1
+       }
+   ]
 }
 ```
 
@@ -221,34 +224,36 @@ JSON output:
 ```
 Application Base Information =>
 {
-    "technologies": [
-        {
-            "cors": false,
-            "description": "Application which contains backend",
-            "enable": false,
-            "icon": "ServerIcon",
-            "id": "server",
-            "is_default": false,
-            "name": "Server",
-            "order": 0
-        },
-        {
-            "cors": true,
-            "description": "Application which contains frontend",
-            "enable": false,
-            "icon": "ChromeIcon",
-            "id": "client",
-            "is_default": false,
-            "name": "Client",
-            "order": 1
-        }
-    ]
+   "technologies": [
+       {
+           "cors": false,
+           "description": "Application which contains backend",
+           "enable": false,
+           "icon": "ServerIcon",
+           "id": "server",
+           "is_default": false,
+           "name": "Server",
+           "order": 0
+       },
+       {
+           "cors": true,
+           "description": "Application which contains frontend",
+           "enable": false,
+           "icon": "ChromeIcon",
+           "id": "client",
+           "is_default": false,
+           "name": "Client",
+           "order": 1
+       }
+   ]
 }
 ```
 
 ## **Get base configuration information for Application**
 
-These information may be useful when you need to input the required flags during the creation of an application. To get these information, use the following command:
+
+This information may be useful when you need to input the required flags during the creation of an application. To get these information, use the following command:
+
 
 ```
 # onqlave application base
@@ -262,60 +267,60 @@ JSON output:
 ```
 Application Base Information =>
 {
-    "technologies": [
-        {
-            "cors": false,
-            "description": "Application which contains backend",
-            "enable": false,
-            "icon": "ServerIcon",
-            "id": "server",
-            "is_default": false,
-            "name": "Server",
-            "order": 0
-        },
-        {
-            "cors": true,
-            "description": "Application which contains frontend",
-            "enable": false,
-            "icon": "ChromeIcon",
-            "id": "client",
-            "is_default": false,
-            "name": "Client",
-            "order": 1
-        }
-    ]
+   "technologies": [
+       {
+           "cors": false,
+           "description": "Application which contains backend",
+           "enable": false,
+           "icon": "ServerIcon",
+           "id": "server",
+           "is_default": false,
+           "name": "Server",
+           "order": 0
+       },
+       {
+           "cors": true,
+           "description": "Application which contains frontend",
+           "enable": false,
+           "icon": "ChromeIcon",
+           "id": "client",
+           "is_default": false,
+           "name": "Client",
+           "order": 1
+       }
+   ]
 }
 ```
 
 
-## **Explore availabe commands**
+## **Explore available commands**
 
 ```
-# onqlave application 
+# onqlave application
 ```
 ```
 This command is used to manage applications resources.
 
 Usage:
-  onqlave application [command]
+ onqlave application [command]
 
 Examples:
 onqlave application
 
 Available Commands:
-  add         add application by name and attributes
-  archive     archive application by ID
-  describe    describe application by ID
-  disable     disable application by ID
-  enable      enable application by ID
-  list        list applications
-  update      update application by ID and attributes
+ add         add application by name and attributes
+ archive     archive application by ID
+ describe    describe application by ID
+ disable     disable application by ID
+ enable      enable application by ID
+ list        list applications
+ update      update application by ID and attributes
 
 Flags:
-  -h, --help   help for application
+ -h, --help   help for application
 
 Global Flags:
-      --json   Output logs as JSON.  Set to true if stdout is not a TTY.
+     --json   Output logs as JSON.  Set to true if stdout is not a TTY.
 
 Use "onqlave application [command] --help" for more information about a command.
 ```

--- a/docs/guides/cli-guide/administration/arx.md
+++ b/docs/guides/cli-guide/administration/arx.md
@@ -4,8 +4,8 @@ If you skipped the section about <mark>**Arx's interesting meaning**</mark>, you
 
 ## **Before you start**
 
-If you are familiar with allocating cloud computing resources for your company, you will be familiar with the concept of creating and assigning clusters to support your expected workload. With Onqlave, we follow a similar approach to allow you to optimise for speed and availability.
-Inside Onqlave Platform, we consider cluster as Arx.
+If you are familiar with allocating cloud computing resources for your company, you will be familiar with the concept of creating and assigning arx to support your expected workload. With Onqlave, we follow a similar approach to allow you to optimise for speed and availability.
+Inside Onqlave Platform, we consider arx as Arx.
 
 
 
@@ -25,7 +25,7 @@ When you are ready to interact, you can go through the below list of commands to
 
 To create an Arx, simply input the following command into the CLI. Please pay attention to the flags and their availabe assigned values.
 There are several configurable attributes of an Arx that are grouped into 4 sections: 
-- **Planning**: We support you in segregating the development, testing, staging and production by providing single purposed cluster for each of your desired environment including: development, testing, staging, production.
+- **Planning**: We support you in segregating the development, testing, staging and production by providing single purposed arx for each of your desired environment including: development, testing, staging, production.
 
 - **Cloud Provider**: The choice of cloud provider determines which service is used to store your information. This allows for you to choose a cloud provider that your organisation already uses. At present we only support Google, but more providers are coming soon.
 
@@ -148,7 +148,7 @@ There is another JSON output if you append the flag **--json** to the end of the
 ```
 List Arx =>
 {
-    "clusters": [
+    "arx": [
         {
             "acl": {
                 "can": {
@@ -159,13 +159,13 @@ List Arx =>
                     "unseal": false
                 },
                 "can_not": {
-                    "unseal_reason": "You don't have access to unseal the cluster as you are not the owner | only sealed clusters can be unsealed!"
+                    "unseal_reason": "You don't have access to unseal the arx as you are not the owner | only sealed arx can be unsealed!"
                 }
             },
             "availability_message": "",
             "description": "",
             "encryption_method": "aes-gcm-128",
-            "id": "cluster--id_string_here",
+            "id": "arx--id_string_here",
             "is_default": false,
             "name": "my_1st_arx",
             "owner": "your_email@here.com",
@@ -272,7 +272,7 @@ For more information, read our documentation at https://docs.onqlave.com/
 
 In contrary to seal, we just need to alter the command:
 ```
-# onqlave arx unseal cluster--xQ9TpIAzI-Mf_IKm9_nAv
+# onqlave arx unseal arx--xQ9TpIAzI-Mf_IKm9_nAv
 ```
 
 And see the result:
@@ -342,7 +342,7 @@ Arx Base Information =>
     ],
     "plans": [
         {
-            "description": "Highly available clusters that scale instantly",
+            "description": "Highly available arx that scale instantly",
             "enable": true,
             "icon": "ServerIcon",
             "id": "serverless",
@@ -351,7 +351,7 @@ Arx Base Information =>
             "order": 0
         },
         {
-            "description": "Didicated single tenant clusters. For more information, contact sales@onqlave.com",
+            "description": "Didicated single tenant arx. For more information, contact sales@onqlave.com",
             "enable": false,
             "icon": "BoxIcon",
             "id": "dedicated",

--- a/docs/guides/cli-guide/overview-cli.md
+++ b/docs/guides/cli-guide/overview-cli.md
@@ -82,7 +82,7 @@ In the CLI, you can try this formula to get help about all provided commands:
 # onqlave help {your_want_to_know_command}
 ```
 
-You may select **{your_preffered_command}** from this list
+You may select **{your_preferred_command}** from this list
 
 ```
 Available Commands:
@@ -106,4 +106,4 @@ Use "onqlave [command] --help" for more information about a command.
 
 ## **Looking for another way of interaction ?**
 
-If this is not your preffered way, considering [the Graphical Web Interface here](../web-app-guide/overview-gui.md)
+If this is not your preferred way, considering [the Graphical Web Interface here](../web-app-guide/overview-gui.md)

--- a/docs/guides/cli-guide/overview-cli.md
+++ b/docs/guides/cli-guide/overview-cli.md
@@ -34,26 +34,26 @@ The output should look like this:
 
 ```
 Usage:
-  onqlave [command]
+ onqlave [command]
 
 Examples:
 onqlave
 
 Available Commands:
-  application application management
-  arx         arx management
-  auth        authentication
-  completion  Generate the autocompletion script for the specified shell
-  config      config environment variables
-  help        Help about any command
-  key         api key management
-  tenant      tenant management
-  user        user management
+ application application management
+ arx         arx management
+ auth        authentication
+ completion  Generate the auto completion script for the specified shell
+ config      config environment variables
+ help        Help about any command
+ key         api key management
+ tenant      tenant management
+ user        user management
 
 Flags:
-  -h, --help      help for onqlave
-      --json      JSON Output. Set to true if stdout is not a TTY.
-  -v, --version   version for onqlave
+ -h, --help      help for onqlave
+     --json      JSON Output. Set to true if stdout is not a TTY.
+ -v, --version   version for onqlave
 
 Use "onqlave [command] --help" for more information about a command.
 
@@ -70,8 +70,8 @@ If the initialization is success, the terminal will look like this
 
 ```
 If the configurations was inited successfully, there should be a output like following
-🎉 Done!  You successfully initialize your environment . Next step is to signup/login is you already haven't.                                                                                                             
-For more information, read our documentation at https://www.onqlave.com/docs 
+🎉 Done!  You successfully initialize your environment . Next step is to signup/login if you already haven't.                                                                                                            
+For more information, read our documentation at https://www.onqlave.com/docs
 ```
 
 ## **Explore the help for each command**
@@ -86,20 +86,20 @@ You may select **{your_preferred_command}** from this list
 
 ```
 Available Commands:
-  application application management
-  arx         arx management
-  auth        authentication
-  completion  Generate the autocompletion script for the specified shell
-  config      config environment variables
-  help        Help about any command
-  key         api key management
-  tenant      tenant management
-  user        user management
+ application application management
+ arx         arx management
+ auth        authentication
+ completion  Generate the auto completion script for the specified shell
+ config      config environment variables
+ help        Help about any command
+ key         api key management
+ tenant      tenant management
+ user        user management
 
 Flags:
-  -h, --help      help for onqlave
-      --json      JSON Output. Set to true if stdout is not a TTY.
-  -v, --version   version for onqlave
+ -h, --help      help for onqlave
+     --json      JSON Output. Set to true if stdout is not a TTY.
+ -v, --version   version for onqlave
 
 Use "onqlave [command] --help" for more information about a command.
 ```

--- a/docs/guides/cli-guide/overview-cli.md
+++ b/docs/guides/cli-guide/overview-cli.md
@@ -11,10 +11,10 @@ In addition, you can try to <mark>[get comfortable with docker](https://docs.doc
 Use this command to get our docker image:
 
 ```
-docker pull australia-southeast1-docker.pkg.dev/temp-control-plane/onqlave/onqlavelabs/onqlave.all:{$cli-version}
+docker pull ghcr.io/onqlavelabs/onqlavelabs/onqlave.all:{cli_version_number}
 ```
 
-Replace **{$cli-version}** with your preferred version. We always recommend the latest version. You can check out <mark>[the list of our releases here](https://github.com/onqlavelabs/onqlave.all/releases)</mark> for an exact version number.
+Replace **{$cli-version}** with your preferred version. We always recommend the latest version. You can check out <mark>[the list of our releases here](https://github.com/onqlavelabs/onqlave.all/pkgs/container/onqlavelabs%2Fonqlave.all)</mark> for an exact version number.
 
 ## **Launch the container**
 

--- a/docs/guides/cli-guide/platform/account.md
+++ b/docs/guides/cli-guide/platform/account.md
@@ -18,26 +18,26 @@ The result should look like this:
 ```
 Tenant 'tenant--cr7ZHkeyjdWycfsPF' Information =>
 {
-    "data": {
-        "acl": {
-            "can": {
-                "edit": true
-            },
-            "can_not": null
-        },
-        "created_on": "2023-04-06T07:16:44.169507Z",
-        "owner_email": "your_email@host.com",
-        "tenant_id": "tenant--cr7ZHkeyjdWycfsPF",
-        "tenant_label": "dc",
-        "tenant_name": "dc-tenant-1"
-    },
-    "error": {
-        "code": 0,
-        "correlation_id": "",
-        "details": null,
-        "message": "",
-        "status": ""
-    }
+   "data": {
+       "acl": {
+           "can": {
+               "edit": true
+           },
+           "can_not": null
+       },
+       "created_on": "2023-04-06T07:16:44.169507Z",
+       "owner_email": "your_email@host.com",
+       "tenant_id": "tenant--cr7ZHkeyjdWycfsPF",
+       "tenant_label": "dc",
+       "tenant_name": "dc-tenant-1"
+   },
+   "error": {
+       "code": 0,
+       "correlation_id": "",
+       "details": null,
+       "message": "",
+       "status": ""
+   }
 }
 ```
 
@@ -67,30 +67,30 @@ You can double check the updated result by using the **describe** command above:
 └────────────────────────────────────────────┘
 ```
 
-## **Explore availabe commands**
+## **Explore available commands**
 
 ```
-# onqlave tenant 
+# onqlave tenant
 ```
 
 ```
-This command is used to manage tenants resource.
+This command is used to manage tenants' resources.
 
 Usage:
-  onqlave tenant [command]
+ onqlave tenant [command]
 
 Examples:
 onqlave tenant
 
 Available Commands:
-  describe    describe tenant
-  update      update tenant by name and label
+ describe    describe tenant
+ update      update tenant by name and label
 
 Flags:
-  -h, --help   help for tenant
+ -h, --help   help for tenant
 
 Global Flags:
-      --json   JSON Output. Set to true if stdout is not a TTY.
+     --json   JSON Output. Set to true if stdout is not a TTY.
 
 Use "onqlave tenant [command] --help" for more information about a command.
 ```

--- a/docs/guides/sdks/sdk-c-sharp.md
+++ b/docs/guides/sdks/sdk-c-sharp.md
@@ -1,0 +1,1 @@
+The SDK for C# will be available soon!

--- a/docs/guides/sdks/sdk-go.md
+++ b/docs/guides/sdks/sdk-go.md
@@ -1,0 +1,2 @@
+{!external-sources/sdk-go.md!lines=1-6 24-151}
+

--- a/docs/guides/sdks/sdk-java.md
+++ b/docs/guides/sdks/sdk-java.md
@@ -1,0 +1,1 @@
+The SDK for Java will be available soon!

--- a/docs/guides/sdks/sdk-node.md
+++ b/docs/guides/sdks/sdk-node.md
@@ -1,2 +1,2 @@
-{!external-sources/sdk-go.md!lines=1-6 24-136}
+{!external-sources/sdk-node.md!lines=1-6 24-136}
 

--- a/docs/guides/sdks/sdk-node.md
+++ b/docs/guides/sdks/sdk-node.md
@@ -1,0 +1,2 @@
+{!external-sources/sdk-go.md!lines=1-6 24-136}
+

--- a/docs/guides/sdks/sdk-overview.md
+++ b/docs/guides/sdks/sdk-overview.md
@@ -1,15 +1,15 @@
 
 ## Currently supported languages
 
-At the moment, we have enabled SDKs for Go and NodeJS, please kindly check them out below.
+At the moment, we have enabled <mark>SDKs for Go and NodeJS</mark>, please kindly check them out below.
 
 ### Go 
-The SDK for Go is published in [this repository](https://github.com/onqlavelabs/onqlave-go)
+The <mark>[documentation for Go's SDK can be found here](../sdk-go)</mark> and the corresponding <mark>[source code repository is published here](https://github.com/onqlavelabs/onqlave-go)</mark>
 
 
 ### NodeJS 
-The SDK for NodeJS is published in [this repository](https://github.com/onqlavelabs/onqlave-node)
+The <mark>[documentation for NodeJS's SDK can be found here](../sdk-node)</mark> and the corresponding <mark>[source code repository is published here](https://github.com/onqlavelabs/onqlave-node)</mark>
 
 
 ### Incoming SDKs
-We are working for the upcoming SDKs for commonly used languages such as Python, C#, etc.. Stay up-to-date with us.
+We are working for the upcoming SDKs for commonly used languages such as Python, C#, etc.. They will be available soon!

--- a/docs/guides/sdks/sdk-php.md
+++ b/docs/guides/sdks/sdk-php.md
@@ -1,0 +1,1 @@
+The SDK for PHP will be available soon!

--- a/docs/guides/sdks/sdk-py.md
+++ b/docs/guides/sdks/sdk-py.md
@@ -1,0 +1,1 @@
+The SDK for Python will be available soon!

--- a/docs/guides/web-app-guide/administration/apikey.md
+++ b/docs/guides/web-app-guide/administration/apikey.md
@@ -1,7 +1,7 @@
 
 ## **Before you start**
 
-API Keys manager allow you to bring your clusters and applications together. The API Keys created here will draw on all of the unique inputs you have created for the cluster and application that you choose.
+API Keys manager allow you to bring your arx and applications together. The API Keys created here will draw on all of the unique inputs you have created for the arx and application that you choose.
 
 When you create your Access key it is critical that you store it as it will only be displayed once. To preserve the integrity of the key, Onqlave does not keep a record of this. Do not close the final window  until you have made this record!
 

--- a/docs/guides/web-app-guide/administration/apikey.md
+++ b/docs/guides/web-app-guide/administration/apikey.md
@@ -1,7 +1,9 @@
 
 ## **Before you start**
 
-API Keys manager allow you to bring your arx and applications together. The API Keys created here will draw on all of the unique inputs you have created for the arx and application that you choose.
+
+API Keys manager allows you to bring your arx and applications together. The API Keys created here will draw on all of the unique inputs you have created for the arx and application that you choose.
+
 
 When you create your Access key it is critical that you store it as it will only be displayed once. To preserve the integrity of the key, Onqlave does not keep a record of this. Do not close the final window  until you have made this record!
 
@@ -21,7 +23,7 @@ To create an api key, firstly, you need to select the associated application...
 
 ![api-key-create-2](https://t36712295.p.clickup-attachments.com/t36712295/1b3bcf20-fff7-45d2-bf3c-e1f6ccd3864c/api-key-2%20(1).png)
 
-You also have a summarize menu to review all the neccesary information before actually create the API key.
+You also have a summarize menu to review all the necessary information before actually creating an API key.
 
 ![api-key-create-3](https://t36712295.p.clickup-attachments.com/t36712295/d329c7c6-86aa-4bba-b8a2-842f428072ec/api-key-2%20(2).png)
 
@@ -42,7 +44,7 @@ You can browse the API Key dashboard as well as the Arx Dashboard and Applicatio
 ![api-key-dashboard-1](https://t36712295.p.clickup-attachments.com/t36712295/91304976-9bdb-46a6-897a-f782da71fc8a/api-key-2%20(4).png)
 
 
-## **Delete the API Key** 
+## **Delete the API Key**
 
 **Who can perform this operation?**
 
@@ -53,8 +55,8 @@ To delete an API Key, you can simply select the one you desired and delete it.
 
 ![api-key-delete-1](https://t36712295.p.clickup-attachments.com/t36712295/edd779f5-81d4-4b1a-845b-75a194cab85a/api-key-2%20(5).png)
 
-The process is the same as archiving application and deleting arx. However, you also have to type exact the same API Key. You can hover above your desired one and copy it in to clipboard before deleting.
+The process is the same as archiving applications and deleting arx. However, you also have to type exactly the same API Key. You can hover above your desired one and copy it into clipboard before deleting.
 
-After deletion, the API Key dashboard is updated instantly. 
+After deletion, the API Key dashboard is updated instantly.
 
 ![api-key-delete-3](https://t36712295.p.clickup-attachments.com/t36712295/d7dd07ec-a546-48c7-af5d-074223f6f290/api-key-2%20(7).png)

--- a/docs/guides/web-app-guide/administration/application.md
+++ b/docs/guides/web-app-guide/administration/application.md
@@ -1,7 +1,8 @@
 
 ## **Before you start**
 
-The Applications page will allow you to create and allocate the unique identifiers for your front and backend applications to be used when creating API Keys. This seperate Application workflow ensures you have easy access to enabling, disabling and archiving applications as needed.
+The Applications page will allow you to create and allocate the unique identifiers for your front and backend applications to be used when creating API Keys. This separated Application workflow ensures you have easy access to enabling, disabling and archiving applications as needed.
+
 
 When the application reference is created, an API token and encryption key is established. Note that Onqlave does not allow you to permanently delete any applications, however they can be archived, which will then disable the respective API token and encryption key.
 
@@ -15,11 +16,11 @@ The web app interface provides a convenient way to fill up all the required info
 
 ![app-create-1](https://t36712295.p.clickup-attachments.com/t36712295/ece9e8ba-6c1c-4920-ac14-0cfcf801984e/application-2.png)
 
-You can delegate the ownership of your application to other account/user. But pay attention to the currently supported roles and its available operations.
+You can delegate the ownership of your application to another account/user. But pay attention to the currently supported roles and its available operations.
 
 ![app-create-1-5](https://t36712295.p.clickup-attachments.com/t36712295/60229ba4-e3fb-489d-8e75-6ef41e82e976/application-2%20(1).png)
 
-The same [summarize screen as included in the creation process of Arx](../../administration/arx/#4-select-your-encryption-mechanism) will help you review all the neccessary information before actually creating the application.
+The same [summarize screen as included in the creation process of Arx](../../administration/arx/#4-select-your-encryption-mechanism) will help you review all the necessary information before actually creating the application.
 
 ![app-create-2](https://t36712295.p.clickup-attachments.com/t36712295/dda86ea2-89b8-4b19-8f2f-d65e2c4e6be3/application-2%20(2).png)
 
@@ -30,7 +31,7 @@ The same [summarize screen as included in the creation process of Arx](../../adm
 
 - [Platform Owner](http://localhost:8000/guides/web-app-guide/platform/access/#1-platform-owner)
 
-In the application dashboard, you can see the total number of actived, disabled and archived applications as well as some basic information of each application. You can also select any existed application to modify, disabled or archive it. 
+In the application dashboard, you can see the total number of activated, disabled and archived applications as well as some basic information of each application. You can also select any existing application to modify, disabled or archive it.
 
 ![app-dashboard-1](https://t36712295.p.clickup-attachments.com/t36712295/d07ad9a5-5e39-45ce-96f6-9cc07f00ab9d/application-2%20(3).png)
 
@@ -44,7 +45,7 @@ You can also enable/disable an application. This is a required step before archi
 
 ![app-enable-disable-2](https://t36712295.p.clickup-attachments.com/t36712295/31e5276a-4644-4437-96df-35966d030f79/application-2-9.png)
 
-If the enable/disable process is success. The status of the selected application will be updated in the application dashboard.
+If the enable/disable process is successful. The status of the selected application will be updated in the application dashboard.
 
 ![app-enable-disable-3](https://t36712295.p.clickup-attachments.com/t36712295/2cb1d9cb-8645-4b28-92f6-912037caed48/application-2%20(4).png)
 
@@ -55,12 +56,13 @@ If the enable/disable process is success. The status of the selected application
 
 - [Platform Owner](http://localhost:8000/guides/web-app-guide/platform/access/#1-platform-owner)
 
-Since we do not support deleting application, you can archive it. Before archiving an application, you have to disable it like the previous step.
+Since we do not support deleting applications, you can archive it. Before archiving an application, you have to disable it like the previous step.
 
 Archiving an application requires you to type in the name of that application correctly.
 
-If the archiving process is success. The status of the selected application will be updated in the application dashboard.
+If the archiving process is successful. The status of the selected application will be updated in the application dashboard.
 
-By toogling the **Show Archived** switch, you can see the archived applications along with the active applications.
+By toggling the **Show Archived** switch, you can see the archived applications along with the active applications.
+
 
 ![app-archive-4](https://t36712295.p.clickup-attachments.com/t36712295/4354808e-5235-4112-b1b1-6c4279f367b7/application-2-8.png)

--- a/docs/guides/web-app-guide/administration/arx.md
+++ b/docs/guides/web-app-guide/administration/arx.md
@@ -1,13 +1,13 @@
 
 ## **Inspiration**
 
-The term <mark>**Arx**</mark> is actually a Latin word means [**Citadel**](https://en.wikipedia.org/wiki/Arx_(Roman)#:~:text=Arx%20is%20a%20Latin%20word%20meaning%20%22citadel%22.) that relates to a fort or a castle for the defence of a place. In the digital world, arx is associated as the castle for the defence of privacy.
+The term <mark>**Arx**</mark> is actually a Latin word means [**Citadel**](https://en.wikipedia.org/wiki/Arx_(Roman)#:~:text=Arx%20is%20a%20Latin%20word%20meaning%20%22citadel%22.) that relates to a fort or a castle for the defence of a place. In the digital world, an arx is associated as a castle for the defence of privacy.
 
 ![arx-1](https://t36712295.p.clickup-attachments.com/t36712295/b5404ed7-d590-41b5-9fc7-fea9588782cb/arx-2%20(1).jpg)
 
 ## **Before you start**
 
-If you are familiar with allocating cloud computing resources for your company, you will be familiar with the concept of creating and assigning arx to support your expected workload. With Onqlave, we follow a similar approach to allow you to optimise for speed and availability.
+If you are familiar with allocating cloud computing resources for your company, you will be familiar with the concept of creating and assigning an arx to support your expected workload. With the Onqlave Platform, we follow a similar approach to allow you to optimise for speed and availability.
 
 ### **Review the provided permission/role**
 
@@ -26,11 +26,11 @@ There are several configurable attributes of an Arx that are grouped into 4 sect
 - Region
 - Encryption mechanism
 
-We will go through all of these 4 configurable section during the creation process of an Arx.
+We will go through all of these 4 configurable sections during the creation process of an Arx.
 
 ### **1. Choose your plan**
 
-We support you in [segregating the development, testing, staging and production](https://www.isms.online/iso-27002/control-8-31-separation-of-development-test-and-production-environments/#purpose) by providing single purposed arx for each of your desired environment including: development, testing, staging, production.
+We support you in [segregating the development, testing, staging and production](https://www.isms.online/iso-27002/control-8-31-separation-of-development-test-and-production-environments/#purpose) by providing a single purpose arx for each of your desired environment including: development, testing, staging, production.
 
 ![arx-plan](https://t36712295.p.clickup-attachments.com/t36712295/90cb27dd-6df2-427c-b33f-f5c9ca1c943a/arx-2.png){loading=lazy}
 
@@ -42,14 +42,14 @@ The choice of cloud provider determines which service is used to store your info
 
 ### **3. Select your preferred region**
 
-The choice of region allows you to determine which geography you would like the data to reside. This may an important factor for data localisation / data residency requirements for sensitive data, whilst there can also be additional [speed and efficiency] benefits from having the data reside in the same geography as the rest of your information.
+The choice of region allows you to determine which geography you would like the data to reside. This may be an important factor for data localisation / data residency requirements for sensitive data, whilst there can also be additional [speed and efficiency] benefits from having the data reside in the same geography as the rest of your information.
 
 **
 ### **4. Select your encryption mechanism**
 
 We only offer encryption services based on the highest performance encryption algorithms. You have the choice of AES-128, AES-256 or [CHACHA20-POLY1305](https://www.rfc-editor.org/rfc/rfc7539), with the latter offering stronger encryption but at a lower processing speed.
 
-The key rotation frequency determines how regularly the encryption keys are changed, to ensure that your information remains safe. 
+The key rotation frequency determines how regularly the encryption keys are changed, to ensure that your information remains safe.
 
 ![arx-encryption](https://t36712295.p.clickup-attachments.com/t36712295/e8b7d50d-8873-40f8-b7e4-2ee8ed343834/arx-2%20(1).png){loading=lazy}
 
@@ -79,7 +79,7 @@ The overview of Arx will provide basic information about the total number of arx
 
 - [Platform Owner](../../platform/access/#1-platform-owner)
 
-There are two sections that you can make changes to your arx:
+There are two sections that you can make changes to any of your arx:
 
 - Arx's name (in the planning section)
 - The key rotation period (in the encryption section)
@@ -91,15 +91,15 @@ There are two sections that you can make changes to your arx:
 
 - [Platform Owner](../../platform/access/#1-platform-owner)
 
-This is a feature supporting you to temporary disable an Arx and enable it in the future without having to reconfiguring everything from scratch.
+This is a feature supporting you to temporarily disable an Arx and enable it in the future without having to reconfigure everything from scratch.
 
 ![arx-seal-1](https://t36712295.p.clickup-attachments.com/t36712295/18766b61-5565-4059-983f-561dd023e84e/arx-2%20(6).png){loading=lazy,data-gallery="seal-an-arx"}
 
-The disabling process will require the confirmation including typing exactly the name of the arx before proceeding to the next step.
+The disabling process will require the confirmation including typing exactly the name of an arx before proceeding to the next step.
 
 ![arx-seal-2](https://t36712295.p.clickup-attachments.com/t36712295/bbb55952-f71e-4cb7-95b7-e31febfbb645/arx-2%20(7).png){loading=lazy,data-gallery="seal-an-arx"}
 
-If the disabling process is success, you can see the status of the selected arx is updated.
+If the disabling process is successful, you can see the status of the selected arx is updated.
 
 ## **Delete an Arx**
 
@@ -111,8 +111,8 @@ To completely delete an arx, you have to go through the same process as disablin
 
 ![arx-delete-1](https://t36712295.p.clickup-attachments.com/t36712295/9b173952-24c6-47d8-bdb4-021418567cf8/arx-2%20(9).png){loading=lazy}
 
-... which also including typing exactly the name of the arx.
+... which also includes typing exactly the name of the arx.
 
 ![arx-delete-2](https://t36712295.p.clickup-attachments.com/t36712295/8185d2c1-a422-4a2a-b00a-ec4b5c96c8a1/arx-2%20(10).png){loading=lazy}
 
-Then the number of remaining arx will be updated instantly in the 
+Then the number of remaining arx will be updated instantly in the  Arx dashboard.

--- a/docs/guides/web-app-guide/administration/arx.md
+++ b/docs/guides/web-app-guide/administration/arx.md
@@ -7,8 +7,7 @@ The term <mark>**Arx**</mark> is actually a Latin word means [**Citadel**](https
 
 ## **Before you start**
 
-If you are familiar with allocating cloud computing resources for your company, you will be familiar with the concept of creating and assigning clusters to support your expected workload. With Onqlave, we follow a similar approach to allow you to optimise for speed and availability.
-Inside Onqlave Platform, we consider cluster as Arx.
+If you are familiar with allocating cloud computing resources for your company, you will be familiar with the concept of creating and assigning arx to support your expected workload. With Onqlave, we follow a similar approach to allow you to optimise for speed and availability.
 
 ### **Review the provided permission/role**
 
@@ -31,7 +30,7 @@ We will go through all of these 4 configurable section during the creation proce
 
 ### **1. Choose your plan**
 
-We support you in [segregating the development, testing, staging and production](https://www.isms.online/iso-27002/control-8-31-separation-of-development-test-and-production-environments/#purpose) by providing single purposed cluster for each of your desired environment including: development, testing, staging, production.
+We support you in [segregating the development, testing, staging and production](https://www.isms.online/iso-27002/control-8-31-separation-of-development-test-and-production-environments/#purpose) by providing single purposed arx for each of your desired environment including: development, testing, staging, production.
 
 ![arx-plan](https://t36712295.p.clickup-attachments.com/t36712295/90cb27dd-6df2-427c-b33f-f5c9ca1c943a/arx-2.png){loading=lazy}
 

--- a/docs/guides/web-app-guide/authentication.md
+++ b/docs/guides/web-app-guide/authentication.md
@@ -1,9 +1,9 @@
 
-## **Double check your account**
+## **Double check on your account**
 
 ---
 
-Make sure that you <mark>[registered for the alpha release](https://www.onqlave.com/contact)</mark>, received our email and followed the instruction specified on email.
+Make sure that you <mark>[registered for the alpha release](https://www.onqlave.com/contact)</mark>, received our email and followed the instruction specified on our email.
 
 ## **Let's get involve**
 
@@ -17,4 +17,4 @@ If your email is activated and you have changed your password for the first time
 
 ![Authentication prompt-2](https://t36712295.p.clickup-attachments.com/t36712295/e042293d-fdb3-49ac-83fe-b1202d5d975a/image.png)
 
-If you haven't changed your password yet, you should follow the instruction of other prompt to set your password
+If you haven't changed your password yet, you should follow the instruction of other prompt to set your password.

--- a/docs/guides/web-app-guide/dashboard.md
+++ b/docs/guides/web-app-guide/dashboard.md
@@ -1,7 +1,7 @@
 
 ## **Main purposes**
 
-The key purpose of the dashboard is to give you a quick snapshot of your current managed assets such as arx, application, api keys as well as your information
+The key purpose of the dashboard is to give you a quick snapshot of your current managed assets such as arx, application, API keys as well as your information
 
 <div style="width:100%;height:0px;position:relative;padding-bottom:50.548%;"><iframe src="https://streamable.com/e/m8fnvi?autoplay=1&nocontrols=1" frameborder="0" width="100%" height="100%" allowfullscreen allow="autoplay" style="width:100%;height:100%;position:absolute;left:0px;top:0px;overflow:hidden;"></iframe></div>
 

--- a/docs/guides/web-app-guide/overview-gui.md
+++ b/docs/guides/web-app-guide/overview-gui.md
@@ -11,4 +11,4 @@ With this graphical interface, you can perform a wide range of interactions with
 
 ## **Looking for another way of interaction ?**
 
-If this is not your preferred way, consider using [**the Command Line Interface** here](../cli-guide/overview-cli.md)
+If this is not your preferred way, considering [**the Command Line Interface** here](../cli-guide/overview-cli.md)

--- a/docs/guides/web-app-guide/overview-gui.md
+++ b/docs/guides/web-app-guide/overview-gui.md
@@ -1,7 +1,7 @@
 ## **What does the GUI of Onqlave Platform do?**
 
 The GUI of Onqlave Platform is provided via web interface.
-With this graphical interface, you can perform a wide range of interactions with essential components of Onqlave platform:
+With this graphical interface, you can perform a wide range of interactions with the essential components of Onqlave platform:
 
 - [Arx](../administration/arx)
 - [Applications](../administration/application)
@@ -11,4 +11,4 @@ With this graphical interface, you can perform a wide range of interactions with
 
 ## **Looking for another way of interaction ?**
 
-If this is not your preffered way, considering [**the Command Line Interface** here](../cli-guide/overview-cli.md)
+If this is not your preferred way, consider using [**the Command Line Interface** here](../cli-guide/overview-cli.md)

--- a/docs/guides/web-app-guide/platform/access.md
+++ b/docs/guides/web-app-guide/platform/access.md
@@ -1,7 +1,7 @@
 
 ## **Description**
 
-This section is dedicated to manage the participating users in your organization.
+This section is dedicated to managing the participating users in your organization.
 
 
 ## **Access Dashboard**
@@ -12,9 +12,11 @@ Another dashboard is provided for your convenience in exploring the basic inform
 
 ## **Add & invite a new user**
 
-You can add your preferred user into your managed tenant by interacting with the web applicaiton. When successfully adding users to your system, our system will automatically send invitation email with activation link to users. 
+You can add your preferred user into your managed tenant by interacting with the web application. When successfully adding users to your system, our system will automatically send an invitation email with an activation link to users.
 
-The most important part when you adding a new user to your managed platfor is assinging roles. Currently we support three roles:
+
+The most important part when you add a new user to your managed platform is assigning roles. Currently we support three roles:
+
 
 - Platform Owner
 - Platform Admin

--- a/docs/guides/web-app-guide/platform/account.md
+++ b/docs/guides/web-app-guide/platform/account.md
@@ -1,13 +1,11 @@
 
 ## **Description**
 
-This section will help you manage your account information divided into three sub-sections:
+This section will help you manage your account information divided into three subsections:
 
 - Profile
 - Security
 - Organization
-
-
 
 ## **Account Profile**
 
@@ -18,7 +16,7 @@ Except the registered email address, every information in this section is updata
 
 ## **Account Security**
 
-At the current release, we provide basic security features for your account including password changing 
+At the current release, we provide basic security features for your account including password changing
 
 ![account-2](https://t36712295.p.clickup-attachments.com/t36712295/c038a80b-6ce5-41f3-b29d-9870b3d5a767/access%2Baccount-2.png)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -106,6 +106,9 @@ nav:
               - "Access": guides/cli-guide/platform/access.md
   - "SDKs": 
     - "Overview": guides/sdks/sdk-overview.md
-    - "Go": guides/sdks/sdk-go.md
-    - "Node": guides/sdks/sdk-node.md
-              
+    - "SDK-Go": guides/sdks/sdk-go.md
+    - "SDK-Node": guides/sdks/sdk-node.md
+    - "SDK-Python": guides/sdks/sdk-py.md 
+    - "SDK-Java": guides/sdks/sdk-java.md
+    - "SDK-php": guides/sdks/sdk-php.md   
+    - "SDK-C#": guides/sdks/sdk-c-sharp.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,6 +74,8 @@ markdown_extensions:
   - pymdownx.emoji:
       emoji_index: !!python/name:materialx.emoji.twemoji
       emoji_generator: !!python/name:materialx.emoji.to_svg
+  - markdown_include.include:
+      base_path: docs
   
 
 nav:
@@ -104,4 +106,6 @@ nav:
               - "Access": guides/cli-guide/platform/access.md
   - "SDKs": 
     - "Overview": guides/sdks/sdk-overview.md
+    - "Go": guides/sdks/sdk-go.md
+    - "Node": guides/sdks/sdk-node.md
               


### PR DESCRIPTION
In this PR:
- Fixed spellings errors, recommended by Xander
- Add 2 SDK sections for Go and Node, I copy the current version of the README.md files on both the 2 repos of Onqlave Go and Node SDK, put these README.md inside the Platform doc repo and using the plugin **markdown_include** to selectively include the SDK doc (except the Table of Contents part - because Mkdocs automatically handles the ToC already)