### PR TITLE
add install command for lib markdown-include in workflow file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,4 +20,5 @@ jobs:
           key: ${{ github.ref }}
           path: .cache
       - run: pip install mkdocs-material 
+      - run: pip install markdown-include
       - run: mkdocs gh-deploy --force


### PR DESCRIPTION
I add an install command for the lib **markdown_include** (use to selectively include the content of README.md in SDKs) to fix the error below:

![image](https://github.com/onqlavelabs/onqlave.docs/assets/125652531/efb53657-0132-4a45-8c0b-93ef049103d6)
