### PR TITLE
Fix the hidden base command section for arx, application in the CLI guide

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,4 +20,5 @@ jobs:
           key: ${{ github.ref }}
           path: .cache
       - run: pip install mkdocs-material 
+      - run: pip install markdown-include
       - run: mkdocs gh-deploy --force

--- a/docs/guides/cli-guide/administration/apikey.md
+++ b/docs/guides/cli-guide/administration/apikey.md
@@ -67,6 +67,21 @@ By default, the result will be formatted in a table.
 # onqlave key delete your_app_key_id
 ```
 
+## **Get base configuration information for API Keys**
+
+Before interacting with the API key, you may need to retrieve all the base information about arx and application. The most frequently used information when interacting with API key via CLI are IDs of arx, application and owner
+
+
+```
+# onqlave key base     
+```
+
+Output should be similar to this:
+ <!-- you can alternate the format into JSON by appending **--json** into the end of the command: -->
+
+![api-key-base](https://t36712295.p.clickup-attachments.com/t36712295/ce103cc9-2d3a-4bce-9d30-2d6bc0795fdf/image.png)
+
+
 ## **Explore available commands**
 
 ```
@@ -99,19 +114,6 @@ Use "onqlave key [command] --help" for more information about a command.
 ```
 
 
-## **Get base configuration information for API Keys**
-
-Before interacting with the API key, you may need to retrieve all the base information about arx and application. The most frequently used information when interacting with API key via CLI are IDs of arx, application and owner
-
-
-```
-# onqlave key base     
-```
-
-Output should be similar to this:
- <!-- you can alternate the format into JSON by appending **--json** into the end of the command: -->
-
-![api-key-base](https://t36712295.p.clickup-attachments.com/t36712295/ce103cc9-2d3a-4bce-9d30-2d6bc0795fdf/image.png)
 
 <!-- ```
 API Key Base Information =>
@@ -247,4 +249,5 @@ API Key Base Information =>
        }
    ]
 }  
-``` -->
+``` 
+-->

--- a/docs/guides/cli-guide/administration/application.md
+++ b/docs/guides/cli-guide/administration/application.md
@@ -202,7 +202,8 @@ Application Base Information =>
        }
    ]
 }
-``` -->
+``` 
+-->
 
 ## **Explore available commands**
 

--- a/docs/guides/cli-guide/administration/arx.md
+++ b/docs/guides/cli-guide/administration/arx.md
@@ -180,7 +180,8 @@ List Arx =>
         }
     ]
 }
-``` -->
+``` 
+-->
 
 ## **Update an arx**
 
@@ -591,7 +592,8 @@ Arx Base Information =>
         }
     ]
 }
-``` -->
+```
+-->
 
 ## **Explore the supported interaction commands with Arx**
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -104,11 +104,11 @@ nav:
           - "Platform":
               - "Account": guides/cli-guide/platform/account.md
               - "Access": guides/cli-guide/platform/access.md
-  - "SDKs": 
-    - "Overview": guides/sdks/sdk-overview.md
-    - "SDK-Go": guides/sdks/sdk-go.md
-    - "SDK-Node": guides/sdks/sdk-node.md
-    - "SDK-Python": guides/sdks/sdk-py.md 
-    - "SDK-Java": guides/sdks/sdk-java.md
-    - "SDK-php": guides/sdks/sdk-php.md   
-    - "SDK-C#": guides/sdks/sdk-c-sharp.md
+      - "SDKs": 
+        - "Overview": guides/sdks/sdk-overview.md
+        - "SDK-Go": guides/sdks/sdk-go.md
+        - "SDK-Node": guides/sdks/sdk-node.md
+        - "SDK-Python": guides/sdks/sdk-py.md 
+        - "SDK-Java": guides/sdks/sdk-java.md
+        - "SDK-PHP": guides/sdks/sdk-php.md   
+        - "SDK-C#": guides/sdks/sdk-c-sharp.md


### PR DESCRIPTION
I fix some syntax errors that hide the base command section for arx and application in the CLI guide.